### PR TITLE
Add image parameter passing to the `BoxDecoration` super constructor.

### DIFF
--- a/lib/src/box_decoration.dart
+++ b/lib/src/box_decoration.dart
@@ -16,6 +16,7 @@ class BoxDecoration extends painting.BoxDecoration {
     BoxShape shape = BoxShape.rectangle,
   }) : super(
           color: color,
+          image: image,
           border: border,
           borderRadius: borderRadius,
           boxShadow: boxShadow,


### PR DESCRIPTION
This PR adds an image parameter passing to the `BoxDecoration` super constructor.

Fixes: https://github.com/johynpapin/flutter_inset_box_shadow/issues/10